### PR TITLE
Add start script that runs collectstatic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN pip install pipenv && \
 
 COPY . .
 
-CMD exec gunicorn sato.wsgi:application \
-    --bind 0.0.0.0:8010 \
-    --workers 3 \
-    -t 120
+CMD ./start
 
 EXPOSE 8010

--- a/start
+++ b/start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+python manage.py collectstatic --no-input
+
+exec gunicorn sato.wsgi:application \
+    --bind 0.0.0.0:8010 \
+    --workers 3 \
+    -t 120


### PR DESCRIPTION
For some reason the PVC of the static files resets from time to time. Now `collectstatic` is run on startup to mitigate the problem.